### PR TITLE
Implement PLC write support

### DIFF
--- a/tests/test_plc_client.py
+++ b/tests/test_plc_client.py
@@ -16,6 +16,14 @@ class FakeSnap7Client:
         return self.data_map[key]
 
 
+class FakeSnap7WriteClient:
+    def __init__(self):
+        self.calls = []
+
+    def write_area(self, area, dbnumber, start, data):  # pragma: no cover - simple recorder
+        self.calls.append((area, dbnumber, start, data))
+
+
 class PlcClientReadAllTest(unittest.TestCase):
     def test_read_all_parses_and_converts(self):
         data_map = {
@@ -41,6 +49,32 @@ class PlcClientReadAllTest(unittest.TestCase):
             result = plc.read_all()
         self.assertNotIn("bad/topic", result)
         self.assertTrue(any("Failed to read address" in msg for msg in cm.output))
+
+
+class PlcClientWriteItemTest(unittest.TestCase):
+    def test_write_item_translates_and_encodes(self):
+        import plc_client as pc
+
+        expected_area = pc.snap7.types.Areas.DB if pc.snap7 is not None else 0
+        cases = [
+            ("DB1.DBX0.0", True, 0, bytes([1])),
+            ("DB1.DBB1", 7, 1, bytes([7])),
+            ("DB1.DBW2", 123, 2, (123).to_bytes(2, "big", signed=True)),
+            ("DB1.DBD4", 3.14, 4, struct.pack(">f", 3.14)),
+        ]
+        for address, value, start, data in cases:
+            with self.subTest(address=address):
+                client = FakeSnap7WriteClient()
+                plc = PlcClient({}, client=client)
+                plc.add_item("topic", address)
+                plc.write_item("topic", value)
+                self.assertEqual(client.calls[0], (expected_area, 1, start, data))
+
+    def test_write_item_stores_when_no_client(self):
+        plc = PlcClient({}, client=None)
+        plc.add_item("topic", "DB1.DBW0")
+        plc.write_item("topic", 42)
+        self.assertEqual(plc.read_all()["topic"], 42)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Implement `write_item` to translate S7 DB addresses, encode values and forward to `write_area`
- Add tests and fake client to exercise writing and fallback logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aefa38e5f0832280c7f734c8c243ad