### PR TITLE
Switch to YAML configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # pys7tomqtt
+
+Bridge between Siemens S7 PLCs and MQTT brokers.
+
+## Installation
+
+Install the Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configuration
+
+The application now uses a YAML configuration file.  The default file is
+`config.yaml`; an example configuration is available in
+`config.example.yaml`.
+
+To migrate from older versions using `config.json`, rename the file to
+`config.yaml` and adapt the contents to YAML syntax.
+
+## Running
+
+Execute the connector, optionally providing a custom configuration path:
+
+```bash
+python -m pys7tomqtt.main [path/to/config.yaml]
+```

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,23 @@
+mqtt:
+  host: localhost
+  user: user
+  password: pass
+
+plc:
+  host: 192.168.0.10
+  rack: 0
+  slot: 2
+  port: 102
+
+mqtt_base: s7
+retain_messages: false
+update_time: 1000
+
+devices:
+  - type: light
+    name: Kitchen Light
+    mqtt: kitchen-light
+    state:
+      plc: "DB1.DBX0.0"
+    brightness:
+      plc: "DB1.DBB1"

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import asyncio
-import json
+import yaml
 from typing import Dict
 
 from .mqtt_client import MqttClient
@@ -9,7 +9,7 @@ from .device_factory import device_factory
 
 def load_config(path: str) -> Dict:
     with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        return yaml.safe_load(f)
 
 
 def mqtt_message_factory(devices):
@@ -23,7 +23,7 @@ def mqtt_message_factory(devices):
     return mqtt_message
 
 
-async def main(config_path: str = "config.json") -> None:
+async def main(config_path: str = "config.yaml") -> None:
     cfg = load_config(config_path)
 
     devices: Dict[str, object] = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+paho-mqtt
+python-snap7
+PyYAML


### PR DESCRIPTION
## Summary
- load configuration via `yaml.safe_load` and default to `config.yaml`
- document YAML usage and provide example configuration
- declare PyYAML dependency

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement paho-mqtt)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0a48b3c483229610a6ef4a2c01c1